### PR TITLE
fix: pin the sqlalchemy version to 1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ pyyaml
 snakemake
 sphinx
 sphinx_rtd_theme
-sqlalchemy
+sqlalchemy < 2.0
 termcolor
 tqdm
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ jinja2
 pandas
 pyyaml
 snakemake
-sqlalchemy
+sqlalchemy < 2.0
 termcolor
 tqdm
 wopmars>=0.1.4


### PR DESCRIPTION
I tried to launch the project but got sqlalchemy issues. I realized it was linked to the release of sqlalchemy 2. We might want to migrate later but for now maybe we can just pin the version